### PR TITLE
Fix signal event error

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ code:
         $t_global_access_level = access_get_global_level( $p_user_id );
     - Above this line enter the following event signal:
         $p_user_id = event_signal('EVENT_GROUP_ACCESS_HAS_BUG_LEVEL', array(array(access_get_global_level( $p_user_id ), $p_user_id, $p_project_id)));
+        if (is_array($p_user_id)) {
+            $p_user_id = $p_user_id[0][1];
+        }
 
 2) in core/access_api.php:
     - Find the function access_has_bug_level


### PR DESCRIPTION
When an error occurs, the MantisBT error handler clears all callbacks
(EVENT_GROUP_ACCESS_HAS_BUG_LEVEL) with `event_clear_callbacks()`.

When callbacks are cleared, `event_signal` returns the second parameter
that we have given to it. After that, `$p_user_id` becomes an array and
we don't want that so we put back the initial `$p_user_id` in it.

This patch fixes issue #3